### PR TITLE
chore: update PR title validation workflow

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,37 +1,38 @@
-name: 'Validate PR title'
+name: Validate PR title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
+      - reopened
 
+permissions:
+  pull-requests: read
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@7bfb19c48fc334d3dacb072cf982e81535041209 # v3.4.6
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # https://github.com/commitizen/conventional-commit-types
+          # Keep the allowed types aligned with the release strategy used in the repository.
           types: |
             fix
             feat
             docs
             chore
-            breaking
-            major
             refactor
             revert
+            perf
+            test
+            ci
+            build
+            style
           requireScope: false
-          # When using "Squash and merge" on a PR with only one commit, GitHub
-          # will suggest using that commit message instead of the PR title for the
-          # merge commit, and it's easy to commit this by mistake. Enable this option
-          # to also validate the commit message for one commit PRs.
           validateSingleCommit: false
-          # Related to `validateSingleCommit` you can opt-in to validate that the PR
-          # title matches a single commit to avoid confusion.
           validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
The PR introduces a workflow to enforce semantic conventions on pull request titles.
It validates PR titles against a predefined set of allowed types (`feat`, `fix`, `docs`, `chore`, `refactor`, `revert`, `perf`, `test`, `ci`, `build`, `style`)

Expected PR title format:

* `type: short description`
* `type(scope): short description` (scope is optional)
