### PR TITLE
fix: make externalSecrets data remoteRef.property optional

### DIFF
--- a/charts/interop-eks-cronjob-chart/values.schema.json
+++ b/charts/interop-eks-cronjob-chart/values.schema.json
@@ -286,7 +286,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["key", "property"],
+                "required": ["key"],
                 "additionalProperties": false
               }
             },

--- a/tests/helm-unittest/external-secret/external-secret-no-property.yaml
+++ b/tests/helm-unittest/external-secret/external-secret-no-property.yaml
@@ -1,0 +1,11 @@
+externalSecrets:
+  create: true
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  targetSecret:
+    name: fallback-cronjob-secret
+  data:
+    - secretKey: token
+      remoteRef:
+        key: "/apps/{{ .Values.name }}/token"

--- a/tests/helm-unittest/external-secret/external_secret_test.yaml
+++ b/tests/helm-unittest/external-secret/external_secret_test.yaml
@@ -37,8 +37,31 @@ tests:
           path: spec.data[0].remoteRef.key
           value: /apps/test-cronjob/username
       - equal:
+          path: spec.data[0].remoteRef.property
+          value: username
+      - equal:
           path: spec.data[1].secretKey
           value: password
       - equal:
           path: spec.data[1].remoteRef.key
           value: /apps/test-cronjob/password
+      - equal:
+          path: spec.data[1].remoteRef.property
+          value: password
+
+  - it: omits remoteRef.property when not set
+    values:
+      - external-secret-no-property.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.data[0].secretKey
+          value: token
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: /apps/test-cronjob/token
+      - notExists:
+          path: spec.data[0].remoteRef.property


### PR DESCRIPTION
## Summary

Mirrors pagopa/interop-eks-microservice-chart#90 on the cronjob chart, which had the same inconsistency between schema and template.

The chart's JSON schema marked `externalSecrets.data[].remoteRef.property` as required, but this contradicts both the chart's own template and the upstream operator contract:

- **The template already treats it as optional.** [`templates/externalSecret.yaml:44`](charts/interop-eks-cronjob-chart/templates/externalSecret.yaml) guards rendering with `{{- if .remoteRef.property }}` — that branch only makes sense if absence is allowed.
- **The upstream `ExternalSecret` CRD (`external-secrets.io/v1`) treats it as optional.** `property` is used to extract a sub-field from a JSON-shaped secret; for plain-string secrets (opaque tokens, scalar values in AWS Secrets Manager / SSM) it is meaningless.

The schema constraint forced consumers either to wrap scalar secrets in JSON unnecessarily, or to set a meaningless `property` value just to pass validation.

## Change

- `values.schema.json`: drop `"property"` from the `required` array under `remoteRef`. `key` remains required.
- `tests/helm-unittest/external-secret`: extend the existing test to assert `remoteRef.property` is emitted when set, and add a new case asserting it is omitted when not set, using a new fixture without `property`.

Non-breaking: every existing values file that includes `property` continues to validate and render unchanged.

## Test plan

- [x] `helm unittest` external-secret suite: 3/3 pass, including the new `omits remoteRef.property when not set` case
